### PR TITLE
Enhance Keychain Manager with Type-Specific Metadata and Filtering

### DIFF
--- a/zsh/functions/keychain_manager/add_entry.zsh
+++ b/zsh/functions/keychain_manager/add_entry.zsh
@@ -40,34 +40,59 @@ function add_entry() {
     ((i++))
   done
 
-  # Select environment
-  local env_choice
-  env_choice=$(tum_select "Select environment" "develop" "production")
-  if [[ -z "$env_choice" ]]; then
-    env_choice="develop"
+  # Select type
+  local type
+  type=$(tum_select "Select type" "Other" "GoogleCloud" "APIKey" "Web3Account")
+  if [[ -z "$type" ]]; then
+    type="Other"
   fi
 
-  # Select group
-  local group
-  group=$(tum_select "Select group" "Other" "ApiKey" "Web3" "Database")
-  if [[ -z "$group" ]]; then
-    group="Other"
-  fi
-
-  # Initialize variables
+  # Initialize common variables
   local name=""
   local value=""
   local description=""
+  local group=""
+  local key_name_generated=""
 
-  # Input: name (required)
-  while true; do
-    name=$(tum_input "Enter name (required):")
-    if [[ -n "$name" ]]; then
-      break
-    else
-      tum_error "Name is required"
-    fi
-  done
+  # Input: group (optional, common for all types)
+  group=$(tum_select "Select group" "NoGroup" "Other")
+  if [[ -z "$group" || "$group" == "Other" ]]; then
+    local input_group=""
+    while true; do
+      input_group=$(tum_input "Enter group name (required):")
+      if [[ -n "$input_group" ]]; then
+        group="$input_group"
+        break
+      else
+        tum_error "Group name is required when selecting 'Other'"
+      fi
+    done
+  fi
+
+  # Select environment (common for all types)
+  local env_choice
+  env_choice=$(tum_select "Select environment" "Develop" "Production")
+  if [[ -z "$env_choice" ]]; then
+    env_choice="Develop"
+  fi
+
+  # Collect type-specific metadata based on selected type
+  local additional_metadata="{}"
+
+  case "$type" in
+  "GoogleCloud")
+    collect_googlecloud_metadata
+    ;;
+  "APIKey")
+    collect_apikey_metadata
+    ;;
+  "Web3Account")
+    collect_web3account_metadata
+    ;;
+  "Other")
+    collect_other_metadata
+    ;;
+  esac
 
   # Input: value (required)
   while true; do
@@ -91,27 +116,19 @@ function add_entry() {
     fi
   done
 
-  # Input: description (optional)
+  # Input: description (optional, common for all types)
   description=$(tum_input "Enter description (optional):")
 
   local timestamp
   timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-  # Generate key_name
-  local key_name_generated
-  if [[ -n "$group" ]]; then
-    key_name_generated="${group}_${name}"
-  else
-    key_name_generated="${name}"
-  fi
-
-  # Create JSON metadata
-  local json_data
-  json_data=$(
+  # Create JSON metadata by merging common and type-specific fields
+  local common_data
+  common_data=$(
     cat <<EOJSON
 {
-  "name": "$name",
   "group": "$group",
+  "type": "$type",
   "key_name": "$key_name_generated",
   "environment": "$env_choice",
   "created_at": "$timestamp",
@@ -119,6 +136,9 @@ function add_entry() {
 }
 EOJSON
   )
+
+  local json_data
+  json_data=$(echo "$common_data" | jq --argjson add "$additional_metadata" '. + $add')
 
   # Validate JSON
   if ! echo "$json_data" | jq empty 2>/dev/null; then
@@ -150,4 +170,146 @@ EOJSON
   fi
 
   tum_pause
+}
+
+# Function for collecting metadata for "Other" type
+function collect_other_metadata() {
+  # Input: name (required)
+  while true; do
+    name=$(tum_input "Enter name (required):")
+    if [[ -n "$name" ]]; then
+      break
+    else
+      tum_error "Name is required"
+    fi
+  done
+
+  # Generate key_name for "Other" type
+  key_name_generated="${group}_${type}_${name}"
+
+  # Update additional_metadata
+  additional_metadata=$(
+    cat <<EOF
+{
+  "name": "$name"
+}
+EOF
+  )
+}
+
+# Function to collect GoogleCloud specific metadata
+function collect_googlecloud_metadata() {
+  # key_type is required for GoogleCloud
+  key_type=$(tum_select "Select key type" "ProjectId" "ProjectNumber" "IdentityPoolId" "IdentityPoolProviderId")
+  if [[ -z "$key_type" ]]; then
+    key_type="ProjectId"
+  fi
+
+  # Generate key_name for GoogleCloud
+  key_name_generated="${group}_${type}_${key_type}"
+
+  # Update additional_metadata
+  additional_metadata=$(
+    cat <<EOF
+{
+  "key_type": "$key_type"
+}
+EOF
+  )
+}
+
+# Function to collect APIKey specific metadata
+function collect_apikey_metadata() {
+  # service is required for APIKey
+  local input_service=""
+  while true; do
+    input_service=$(tum_input "Enter service name (required):")
+    if [[ -n "$input_service" ]]; then
+      service="$input_service"
+      break
+    else
+      tum_error "Service name is required"
+    fi
+  done
+
+  # url is optional
+  local url=""
+  url=$(tum_input "Enter URL (optional):")
+
+  # Generate key_name for APIKey
+  key_name_generated="${group}_${type}_${service}"
+
+  # Update additional_metadata
+  additional_metadata=$(
+    cat <<EOF
+{
+  "service": "$service",
+  "url": "$url"
+}
+EOF
+  )
+}
+
+# Function to collect Web3Account specific metadata
+function collect_web3account_metadata() {
+  # key_type is required for Web3Account
+  key_type=$(tum_select "Select key type" "Mnemonic" "Private")
+  if [[ -z "$key_type" ]]; then
+    key_type="Mnemonic"
+  fi
+
+  # label is required
+  local input_label=""
+  while true; do
+    input_label=$(tum_input "Enter label (required):")
+    if [[ -n "$input_label" ]]; then
+      break
+    else
+      tum_error "Label is required"
+    fi
+  done
+  local label="$input_label"
+
+  local index=""
+  local address=""
+
+  # For Private key type, index and address are required
+  if [[ "$key_type" == "Private" ]]; then
+    while true; do
+      index=$(tum_input "Enter index (required for Private key):")
+      if [[ -n "$index" ]]; then
+        break
+      else
+        tum_error "Index is required for Private keys"
+      fi
+    done
+
+    while true; do
+      address=$(tum_input "Enter address (required for Private key):")
+      if [[ -n "$address" ]]; then
+        break
+      else
+        tum_error "Address is required for Private keys"
+      fi
+    done
+  else
+    # For Mnemonic, they are optional
+    index=$(tum_input "Enter index (optional):")
+    address=$(tum_input "Enter address (optional):")
+  fi
+
+  # Generate key_name for Web3Account
+  key_name_generated="${group}_${type}_${key_type}_${label}"
+
+  # Update additional_metadata
+  additional_metadata=$(
+    cat <<EOF
+{
+  "key_type": "$key_type",
+  "label": "$label",
+  "index": "$index",
+  "address": "$address"
+}
+EOF
+  )
 }


### PR DESCRIPTION
## Summary

This pull request introduces significant enhancements to the Keychain Manager scripts, focusing on adding type-specific metadata handling and filtering capabilities. The changes include:

1. **`add_entry.zsh`**:
   - Added support for selecting and handling entry types (`GoogleCloud`, `APIKey`, `Web3Account`, `Other`).
   - Introduced type-specific metadata collection functions (`collect_googlecloud_metadata`, `collect_apikey_metadata`, `collect_web3account_metadata`, `collect_other_metadata`).
   - Improved JSON metadata generation by merging common and type-specific fields.
   - Enhanced group and environment selection logic.

2. **`list_entries.zsh`**:
   - Added filtering by entry type.
   - Dynamically adjusted required and optional properties based on the selected type.
   - Improved property handling to avoid duplicates and ensure accurate display of type-specific fields.

## Dependency Changes

No dependency changes were detected in this update.

## Testing

- Verified the addition of entries with various types and metadata.
- Tested listing entries with and without type filters to ensure accurate filtering and display.

## Additional Notes

These changes improve the flexibility and usability of the Keychain Manager by allowing users to manage entries with more granularity and context-specific metadata.